### PR TITLE
Consistency with README.md

### DIFF
--- a/book/1 - Installing/2 - Compiling Cuberite Yourself.html
+++ b/book/1 - Installing/2 - Compiling Cuberite Yourself.html
@@ -8,7 +8,7 @@
 	It takes care of the compilation process for you. You only need to copy this command to your Bash terminal:
 </p>
 
-<figure class="codebox"><pre><code>bash -c "$(wget -O - https://raw.githubusercontent.com/cuberite/cuberite/master/compile.sh)"</code></pre></figure>
+<figure class="codebox"><pre><code>sh -c "$(wget -O - https://raw.githubusercontent.com/cuberite/cuberite/master/compile.sh)"</code></pre></figure>
 
 <p>	
 	The rest of this section is for those who prefer to manually compile.
@@ -24,7 +24,7 @@
 	Compiling on Linux and related operating systems is easy and simple, although it does require some tools before you can get started. You need a C++ compiler (Clang++ or G++), a C compiler (Clang or GCC), Git, CMake and Make. A simple command to make sure these tools are installed (Ubuntu/Debian) is:
 </b>
 
-<figure class="codebox"><pre><code>sudo apt-get install clang git cmake build-essential</code></pre></figure>
+<figure class="codebox"><pre><code>sudo apt-get install gcc g++ git cmake build-essential</code></pre></figure>
 
 <p>
 	Once the tools are installed, you should clone the Git repo:


### PR DESCRIPTION
Also, beginners who don't know what they're doing should probably install `gcc` and not `clang`, because it's more widely used, and they most likely won't have to re-download a compiler when following some different online guide for some other program.