### PR TITLE
Print-friendly book

### DIFF
--- a/book/0 - Introduction/1 - Introduction.html
+++ b/book/0 - Introduction/1 - Introduction.html
@@ -9,3 +9,13 @@
 <p>
 	The majority of this manual was written by <a href="https://github.com/bearbin">@bearbin</a> and it was assembled by a generator written by <a href="https://github.com/bearbin">@bearbin</a> as well.
 </p>
+
+<h3>Resources</h3>
+
+<ul>
+	<li>Cuberite homepage: <a href="http://cuberite.org">http://cuberite.org</a></li>
+	<li>User manual: <a href="http://book.cuberite.org">http://book.cuberite.org</a></li>
+	<li>Forum: <a href="http://forum.mc-server.org">http://forum.mc-server.org</a></li>
+	<li>Github: <a href="https://github.com/cuberite/cuberite">https://github.com/cuberite/cuberite</a></li>
+	<li>Support E-mail address: <a href="mailto:support@cuberite.org">support@cuberite.org</a></li>
+</ul>

--- a/book/0 - Introduction/2 - What is Cuberite.html
+++ b/book/0 - Introduction/2 - What is Cuberite.html
@@ -1,5 +1,5 @@
 <p>
-	Cuberite is a Free and Open Source (FOSS) Minecraft-compatible Game Server. Cuberite is designed with performance, configurability, and extensibility in mind, and also aims to accurately recreate most vanilla features.  Cuberite is written in C++, and there is also an expansive plugin system that allows for the user to write their own plugins with Lua. In fact, many of the built in commands are implemented by the Core plugin, which has it's own <a href="https://github.com/cuberite/Core">GitHub repository</a> and developer community. For more information on the plugin system and how to use it, as well as how to develop for it, please see {{2.4 - Plugins}}.
+	Cuberite is a Free and Open Source (FOSS) Minecraft-compatible Game Server. Cuberite is designed with performance, configurability, and extensibility in mind, and also aims to accurately recreate most vanilla features.  Cuberite is written in C++, and there is also an expansive plugin system that allows for the user to write their own plugins with Lua. In fact, many of the built in commands are implemented by the Core plugin, which has it's own <a href="https://github.com/cuberite/Core">GitHub repository</a> and developer community. For more information on the plugin system and how to use it, as well as how to develop for it, please see 2.4 - {{2.4 - Plugins}}.
 </p>
 
 <p>

--- a/book/1 - Installing/1 - Pre-Compiled Builds.html
+++ b/book/1 - Installing/1 - Pre-Compiled Builds.html
@@ -1,6 +1,6 @@
 <p>
 	Pre-compiled builds are faster to install and easier to use than compiling your own, and are recommended for beginners.
-	However, if you have hardware for which no pre-compiled build exists it may be neccessary to compile yourself. Compiling yourself also has a significant performance advantage on modern machines. If you know how to use the command line or want extra speed you should {{1.2 - compile Cuberite yourself}}.
+	However, if you have hardware for which no pre-compiled build exists it may be neccessary to compile yourself. Compiling yourself also has a significant performance advantage on modern machines. If you know how to use the command line or want extra speed you should see 1.2 - {{1.2 - compile Cuberite yourself}}.
 </p>
 
 <p>
@@ -14,5 +14,5 @@
 </p>
 
 <p>
-	Once you have downloaded the pre-compiled builds, you can skip straight to {{1.3 - Running Cuberite}}.
+	Once you have downloaded the pre-compiled builds, you can skip straight to 1.3 - {{1.3 - Running Cuberite}}.
 </p>

--- a/book/1 - Installing/2 - Compiling Cuberite Yourself.html
+++ b/book/1 - Installing/2 - Compiling Cuberite Yourself.html
@@ -15,7 +15,7 @@
 </p>
 
 <aside class="warnbox">
-	This process requires use of the command line. If you are not familiar with it, it is recommended that you use the {{1.1 - pre-compiled builds}} instead.
+	This process requires use of the command line. If you are not familiar with it, it is recommended that you use the 1.1 - {{1.1 - pre-compiled builds}} instead.
 </aside>
 
 <h4 id="compilinglinux">Linux/Mac/BSD</h4>

--- a/book/2 - Configuration Basics/1 - Configuration overview.html
+++ b/book/2 - Configuration Basics/1 - Configuration overview.html
@@ -13,7 +13,7 @@
 	</dd>
 	<dt>world/world.ini</dt>
 	<dd>
-		This file configures world-specific aspects. This is where you choose your game mode. See {{3.3 - GameMode}}. Note that if you have multiple worlds, you'll have multiple <code>world.ini</code> files, each stored in <code>&lt;World name&gt;/world.ini</code>.
+		This file configures world-specific aspects. This is where you choose your game mode. See 3.3 - {{3.3 - GameMode}}. Note that if you have multiple worlds, you'll have multiple <code>world.ini</code> files, each stored in <code>&lt;World name&gt;/world.ini</code>.
 	</dd>
 	<dt>monsters.ini</dt>
 	<dd>

--- a/book/2 - Configuration Basics/3 - Worlds.html
+++ b/book/2 - Configuration Basics/3 - Worlds.html
@@ -1,5 +1,6 @@
 <p>
-	By default, there is only one world. That world can be tweaked by editing the file <code>world/world.ini</code>
+	By default, there is only one world. That world can be tweaked by editing the file <code>world/world.ini</code>.
+	You can edit things like the spawn point location and the game mode. See section 3 - {{3 - Configuring world.ini}} for details.
 </p>
 
 <h4>Adding worlds</h4>

--- a/book/3 - Configuring world.ini/1 - What is world.ini.html
+++ b/book/3 - Configuring world.ini/1 - What is world.ini.html
@@ -15,7 +15,7 @@
 </p>
 
 <p>
-	The <code>world.ini</code> file is split into many different sections, each with a name surrounded in square brackets. For example {{3.2 - <code>[SpawnPosition]</code>}} is a section. Each section contains configuration options related to a specific feature of Cuberite.
+	The <code>world.ini</code> file is split into many different sections, each with a name surrounded in square brackets. For example 3.2 - {{3.2 - SpawnPosition}} is a section. Each section contains configuration options related to a specific feature of Cuberite.
 </p>
 
 <h4>Default Settings</h4>


### PR DESCRIPTION
This PR aims to make the book more print friendly by providing actual links in some places, because `a href` is useless when printing.

 - Added a "resources" paragraph with textual urls.
 - Added textual prefixes to all `{{ ... }}` links. I think the generator should do this automatically though.