### PR TITLE
Removed multiworld stability warnings

### DIFF
--- a/book/2 - Configuration Basics/4 - Worlds.html
+++ b/book/2 - Configuration Basics/4 - Worlds.html
@@ -4,7 +4,3 @@
 	You can use this file to edit things like the spawn point location, the game mode, and the diffculty level.
 	See {{3 - Configuring world.ini}} for details.
 </p>
-
-<aside class="warnbox">
-	Multiworld travel is not stable yet. You may encounter crashes if you choose to travel to the Nether or the End.
-</aside>

--- a/book/4 - MultiWorlds/1 - Multiworlds Overview.html
+++ b/book/4 - MultiWorlds/1 - Multiworlds Overview.html
@@ -4,10 +4,6 @@
 	This is explained in the example below.
 </p>
 
-<aside class="warnbox">
-	Multiworld travel is not stable yet. You may encounter bugs. Only do this if you are adventurous!
-</aside>
-
 <h4>Adding Worlds</h4>
 
 <figure class="codebox">


### PR DESCRIPTION
I think multiworld travel is no less stable than the rest of Cuberite now.
To be merged after https://github.com/cuberite/cuberite/issues/2997 is closed.

Closes #66