### PR TITLE
Changed the selection color in codeboxes.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -277,6 +277,13 @@ h2.manual {
 	font-style: normal;
 	font-weight: normal;
 }
+.codebox code::selection {
+    background: #eee;
+}
+.codebox code::-moz-selection {
+    background: #eee;
+}
+
 .infobox, .warnbox {
 	font-size: 0.938em;
 	padding: 1.000em;


### PR DESCRIPTION
I have changed the color that the selection has in the codeboxes to `#eee`, because I think it's too hard to read if you have that what you wanted to select now selected.
And because it's the purpose of codeboxes to copy code from them, I believe it should be easy to read.