### PR TITLE
Empty world documentation

### DIFF
--- a/book/3 - Configuring world.ini/7 - Empty World.html
+++ b/book/3 - Configuring world.ini/7 - Empty World.html
@@ -1,0 +1,14 @@
+<p>
+	To generate a world that only contains air, change the values under the <code>[Generator]</code> section to:
+</p>
+<figure class="codebox">
+<pre><code>BiomeGen=Constant
+ShapeGen=HeightMap
+HeightGen=Flat
+FlatHeight=0
+CompositionGen=SameBlock
+SameBlockType=air
+SameBlockBedrocked=0
+Finishers=
+</code></pre>
+</figure>


### PR DESCRIPTION
Useful information if you need an empty world for pasting schematics in or similar.