### PR TITLE
Small typo

### DIFF
--- a/book/2 - Configuration Basics/5 - Plugins.html
+++ b/book/2 - Configuration Basics/5 - Plugins.html
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-	Cubrite plugins are written in Lua, and interact with the server through an
+	Cuberite plugins are written in Lua, and interact with the server through an
 	 <a href="https://api.cuberite.org/">extensive API</a>. They are
 	designed to be easy to write for anyone with basic programming experience,
 	so if existing plugins don't fill your need you can easily write your own plugins.


### PR DESCRIPTION
An `e` was missing in Cuberite