### PR TITLE
style.css: lighter table background in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -244,11 +244,11 @@ button {
 		color: #2A7C97;
 	}
 	th {
-		background: rgba(0, 0, 0, .7);
+		background: rgba(255, 255, 255, .12);
 	}
 	td,
 	.codebox {
-		background: rgba(0, 0, 0, .4);
+		background: rgba(255, 255, 255, .06);
 	}
 	.infobox {
 		background: #2E3946;
@@ -290,7 +290,6 @@ button {
 		content: attr(data-label);
 		display: block;
 		float: left;
-		font-family: montserratregular,"Helvetica Neue",Helvetica,Arial,sans-serif;
 		margin: 0 1.000em 0 0;
 		text-transform: uppercase;
 	}

--- a/style.css
+++ b/style.css
@@ -104,7 +104,7 @@ li {
 	margin: 0 0 0 2.000em;
 }
 table {
-	border-spacing: 0.125em;
+	border-spacing: 2px;
 	width: 100%;
 }
 th {


### PR DESCRIPTION
Same opacity as in light mode, but using white instead of black.

![Screenshot from 2024-03-24 14-32-02](https://github.com/cuberite/users-manual/assets/8754153/b083159d-87db-46ec-b397-64fd5ee30b8c)
